### PR TITLE
Fix error when using global lambda handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ class AwsSamPlugin {
         }
 
         // Check we have a valid handler
-        if (!properties.Handler || defaultHandler) {
+        if (!properties.Handler && !defaultHandler) {
           throw new Error(`${resourceKey} is missing a Handler`);
         }
         const handler = (properties.Handler || defaultHandler).split(".");


### PR DESCRIPTION
Thanks for the plugin! I found it via your blog article and it's been very useful.

I noticed a bug preventing me from using global handlers. I've tested this fix and it works as expected.