### PR TITLE
fix function name in an error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ class AwsSamPlugin {
           );
         }
       } else {
-        console.log("It looks like SamPlugin.entryPoints() was not called");
+        console.log("It looks like SamPlugin.entry() was not called");
       }
     });
   }


### PR DESCRIPTION
Actually the function name is `entry`, not `entryPoints`